### PR TITLE
sklearn is deprecated, use scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'pandas',
         'scipy',
         'seaborn',
-        'sklearn',
         'statsmodels',
         'tqdm',
     ]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'matplotlib',
         'numpy',
         'pandas',
+        'scikit-learn',
         'scipy',
         'seaborn',
         'statsmodels',


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.